### PR TITLE
[feat] Python + Java 환경 통합을 위한 Dockerfile 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,25 @@
+# 베이스 이미지는 python:3.11-slim (최소한의 사이즈)
 FROM python:3.11-slim
 
+# 필요한 패키지만 설치 (curl은 디버깅/테스트용으로도 유용)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-17-jdk-headless \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# 환경 변수 설정
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# 작업 디렉토리 설정
 WORKDIR /app
 
+# 파이썬 패키지 설치
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# 소스 코드 복사
 COPY . .
 
-EXPOSE 8000
-
+# FastAPI 앱 실행
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
- 기존 Python 3.11-slim 이미지에 OpenJDK 17을 추가하여 FastAPI와 Java 코드 실행이 동시에 가능한 환경 구성
- openjdk-17-jdk 대신 openjdk-17-jdk-headless 패키지를 사용하여 이미지 용량 최적화
- apt 패키지 설치 후 캐시 제거 및 불필요한 파일 정리로 이미지 사이즈 최소화
- JAVA_HOME 및 PATH 환경 변수 설정을 통해 Java 실행 환경 보장
- 기존에 EC2 서버에 별도로 설치하던 Java를 Docker 이미지 내로 통합하여 배포 시 일관성과 유지보수 효율성 향상