### PR TITLE
[refactor] 테스트케이스 캐싱 및 로깅 구조 개선

### DIFF
--- a/app/judge_core.py
+++ b/app/judge_core.py
@@ -11,11 +11,6 @@ import uuid
 import logging
 from app.models import SubmissionRequest, SubmissionResponse
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-)
-
 def sort_key(path):
     return int(re.sub(r"\D", "", path.stem))
 
@@ -41,6 +36,9 @@ def judge_submission(req: SubmissionRequest) -> SubmissionResponse:
         base_path=TESTCASE_BASE_PATH,
         bucket_name=TESTCASE_S3_BUCKET_URL
     )
+
+    logger.info(f"problem_dir : {problem_dir}")
+
     input_files = sorted(problem_dir.glob("input*"), key=sort_key)
     output_files = sorted(problem_dir.glob("output*"), key=sort_key)
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,12 @@ from app.models import SubmissionRequest, SubmissionResponse
 from dotenv import load_dotenv
 import logging
 
+# 전역 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+)
+
 load_dotenv()
 
 app = FastAPI()

--- a/app/util/testcase_loader.py
+++ b/app/util/testcase_loader.py
@@ -1,12 +1,17 @@
 from pathlib import Path
 import os
 import boto3
+import logging
 
 def ensure_testcases_cached(problem_id: int, base_path: str, bucket_name: str):
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+
     """
     문제 ID에 해당하는 테스트케이스 디렉토리가 base_path에 없다면 S3에서 가져온다.
     """
     local_problem_dir = Path(base_path) / f"prob_{problem_id:05d}"
+    logger.info(f"초기 local_problem_dir ={local_problem_dir}")
     
     # 1. 캐시 존재 및 비어 있지 않으면 바로 사용
     if local_problem_dir.exists() and any(local_problem_dir.iterdir()):
@@ -28,4 +33,5 @@ def ensure_testcases_cached(problem_id: int, base_path: str, bucket_name: str):
             local_path = local_problem_dir / filename
             s3.download_file(bucket_name, key, str(local_path))
 
+    logger.info(f"최종 local_problem_dir ={local_problem_dir}")
     return local_problem_dir


### PR DESCRIPTION
- 로깅 설정을 main.py로 이동하여 전역에서 공통 사용하도록 변경
- S3 테스트케이스 다운로드 시 디버깅용 로그 출력 추가