### PR TITLE
[feat] uvicorn 호스트를 127.0.0.1로 제한

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # FastAPI 앱 실행
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "8000"]


### PR DESCRIPTION
- 외부 접근을 차단하고, NGINX 리버스 프록시를 통해서만 접근하도록 uvicorn의 --host 값을 0.0.0.0에서 127.0.0.1로 변경함.