### PR TITLE
[chore] 헬스체크 URL을 http://EC2_HOST:8000 → https://algoduck-judge.duckd…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           echo "🔍 Judge 서버 Health Check 시작"
           for i in {1..10}; do
-            status=$(curl -s -o /dev/null -w "%{http_code}" http://${{ secrets.EC2_HOST }}:8000/health || true)
+            status=$(curl -s -o /dev/null -w "%{http_code}" https://algoduck-judge.duckdns.org/health || true)
             if [ "$status" == "200" ]; then
               echo "✅ Judge 서버 정상 작동 (HTTP 200)"
               exit 0


### PR DESCRIPTION
…ns.org 로 변경

FastAPI를 외부에 직접 노출하지 않고 NGINX 리버스 프록시를 통해 접근하도록 구성했기 때문에, 헬스체크도 외부 도메인 기준의 HTTPS 요청으로 변경함.